### PR TITLE
chore: adds parent_buff for AttributeBuff resources overriding the `_operate` function.

### DIFF
--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -156,6 +156,7 @@ void AttributeBuff::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_duration_merging"), &AttributeBuff::get_duration_merging);
 	ClassDB::bind_method(D_METHOD("get_max_applies"), &AttributeBuff::get_stack_size);
 	ClassDB::bind_method(D_METHOD("get_operation"), &AttributeBuff::get_operation);
+	ClassDB::bind_method(D_METHOD("get_parent_buff"), &AttributeBuff::get_parent_buff);
 	ClassDB::bind_method(D_METHOD("get_queue_execution"), &AttributeBuff::get_queue_execution);
 	ClassDB::bind_method(D_METHOD("get_stack_size"), &AttributeBuff::get_stack_size);
 	ClassDB::bind_method(D_METHOD("get_transient"), &AttributeBuff::get_transient);
@@ -167,6 +168,7 @@ void AttributeBuff::_bind_methods()
 	ClassDB::bind_method(D_METHOD("set_duration_merging", "p_value"), &AttributeBuff::set_duration_merging);
 	ClassDB::bind_method(D_METHOD("set_max_applies", "p_value"), &AttributeBuff::set_stack_size);
 	ClassDB::bind_method(D_METHOD("set_operation", "p_value"), &AttributeBuff::set_operation);
+	ClassDB::bind_method(D_METHOD("set_parent_buff", "p_value"), &AttributeBuff::set_parent_buff);
 	ClassDB::bind_method(D_METHOD("set_queue_execution", "p_value"), &AttributeBuff::set_queue_execution);
 	ClassDB::bind_method(D_METHOD("set_stack_size", "p_value"), &AttributeBuff::set_stack_size);
 	ClassDB::bind_method(D_METHOD("set_transient", "p_value"), &AttributeBuff::set_transient);
@@ -178,6 +180,7 @@ void AttributeBuff::_bind_methods()
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "duration"), "set_duration", "get_duration");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "duration_merging", PROPERTY_HINT_ENUM, "Add:0,Stack:1,Restart:2"), "set_duration_merging", "get_duration_merging");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "operation", PROPERTY_HINT_RESOURCE_TYPE, "AttributeOperation"), "set_operation", "get_operation");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "parent_buff", PROPERTY_HINT_RESOURCE_TYPE, "AttributeBuff"), "set_parent_buff", "get_parent_buff");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_applies"), "set_stack_size", "get_stack_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "stack_size"), "set_stack_size", "get_stack_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "queue_execution", PROPERTY_HINT_ENUM, "Parallel:0,Waterfall:1"), "set_queue_execution", "get_queue_execution");
@@ -254,6 +257,11 @@ Ref<AttributeOperation> AttributeBuff::get_operation() const
 	return operation;
 }
 
+Ref<AttributeBuff> AttributeBuff::get_parent_buff() const
+{
+	return parent_buff;
+}
+
 int AttributeBuff::get_stack_size() const
 {
 	return max_stacking;
@@ -292,6 +300,11 @@ void AttributeBuff::set_duration_merging(int p_value)
 void AttributeBuff::set_operation(const Ref<AttributeOperation> &p_value)
 {
 	operation = p_value;
+}
+
+void AttributeBuff::set_parent_buff(const Ref<AttributeBuff> &p_value)
+{
+	parent_buff = p_value;
 }
 
 void AttributeBuff::set_stack_size(const int p_value)

--- a/src/attribute.hpp
+++ b/src/attribute.hpp
@@ -251,6 +251,9 @@ namespace octod::gameplay::attributes
 		/// @brief Returns the operation to apply as a Ref.
 		/// @return The operation to apply.
 		[[nodiscard]] Ref<AttributeOperation> get_operation() const;
+		/// @brief Gets the parent buff if this buff was programmatically created because the `_operate` function is overloaded.
+		/// @return The `AttributeBuff` if any, `null` otherwise
+		[[nodiscard]] Ref<AttributeBuff> get_parent_buff() const;
 		/// @brief Returns the maximum number of stacks possible.
 		/// @return The maximum number of stacks possible.
 		[[nodiscard]] int get_stack_size() const;
@@ -285,6 +288,9 @@ namespace octod::gameplay::attributes
 		/// @brief Sets the operation to apply.
 		/// @param p_value The operation to apply.
 		void set_operation(const Ref<AttributeOperation> &p_value);
+		/// @brief Sets the parent buff
+		/// @param p_value The parent buff.
+		void set_parent_buff(const Ref<AttributeBuff> &p_value);
 		/// @brief Sets the maximum number of stacks possible.
 		/// @param p_value The maximum number of stacks possible.
 		void set_stack_size(int p_value);
@@ -318,6 +324,8 @@ namespace octod::gameplay::attributes
 		int max_stacking = 0;
 		/// @brief The operation to apply.
 		Ref<AttributeOperation> operation = AttributeOperation::add(0);
+		/// @brief The parent buff
+		Ref<AttributeBuff> parent_buff;
 		/// @brief The queue execution.
 		QueueExecution queue_execution = QUEUE_EXECUTION_PARALLEL;
 		/// @brief The buff is transient and will be not affect the attribute value directly.

--- a/src/attribute_container.cpp
+++ b/src/attribute_container.cpp
@@ -240,6 +240,7 @@ void AttributeContainer::apply_buff(const Ref<AttributeBuff> &p_buff)
 			derived_buff->set_buff_name(p_buff->get_buff_name());
 			derived_buff->set_duration(p_buff->get_duration());
 			derived_buff->set_duration_merging(p_buff->get_duration_merging());
+			derived_buff->set_parent_buff(p_buff);
 			derived_buff->set_queue_execution(p_buff->get_queue_execution());
 			derived_buff->set_unique(p_buff->get_unique());
 			derived_buff->set_stack_size(p_buff->get_stack_size());


### PR DESCRIPTION
To circumvent #21