### PR TITLE
fix: calls setup on entering scene tree

### DIFF
--- a/src/attribute_container.cpp
+++ b/src/attribute_container.cpp
@@ -52,7 +52,7 @@ void AttributeContainer::_bind_methods()
 
 void AttributeContainer::_notification(const int p_what)
 {
-	if (p_what == NOTIFICATION_READY) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
 		setup();
 		set_physics_process(true);
 	} else if (p_what == NOTIFICATION_PHYSICS_PROCESS) {


### PR DESCRIPTION
With this change, the `AbilityContainer` sets up predefined `Attribute`s before the GDScript API calls `_ready()`. Previously, Buffs applied to a predefined Attribute in `_ready()` would not persist past the first frame after the Container, as `setup()` was not called until after the script's `_ready()` function was completed. By changing the notification to `NOTIFICATION_ENTER_TREE` to call `setup()`, we can ensure attributes are fully prepared to receive buffs in the `_ready()` function. 